### PR TITLE
fix: remove redefinition of Serial

### DIFF
--- a/firmware/sd2-card-config.h
+++ b/firmware/sd2-card-config.h
@@ -18,7 +18,6 @@
 /* Select output device for print() function */
 #	define SERIAL_DEVICE	0				/* 0:SerialUSB  1=: Serial UART device */
 #	if SERIAL_DEVICE == 0  	
-#		define Serial Serial				/* Use USB CDC port */
 #		define BPS_9600		/* Nothing */ 
 #		define BPS_115200 	/* Nothing */ 
 #	else


### PR DESCRIPTION
When using this library in the Particle IDE, the following error pops up:

```
sd-card-library/sd2-card-config.h:21:0: warning: "Serial" redefined [enabled by default]
 #  define Serial Serial    /* Use USB CDC port */
 ^
In file included from ./inc/application.h:45:0,
                 from xxx.cpp:2:
../wiring/inc/spark_wiring_usbserial.h:94:0: note: this is the location of the previous definition
 #define Serial _fetch_global_serial()
 ^
In file included from sd-card-library/sd2-card.h:26:0,
                 from sd-card-library/sd-fat-util.h:27,
                 from sd-card-library/sd-fat.h:27,
                 from sd-card-library/sd-card-library.h:18,
                 from wala.cpp:2:
xxx.cpp: In function 'void setup()':
This looks like an error in sd-card-library library. Would you like to create an issue on GitHub to let the author know?
```
